### PR TITLE
CI/CD and Download Compiled Version from Release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: "CI"
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  test:
+    name: CI/CD Test
+    # https://github.com/actions/virtual-environments/
+    runs-on: ubuntu-latest
+    steps:
+
+      - name: 🛎️ Checkout
+        uses: actions/checkout@v3
+
+      - name: 🔧 Setup go
+        uses: actions/setup-go@v4
+        with:
+          go-version-file: 'go.mod'
+
+      # Test
+      - name: 🌡️ Test
+        run: go run main.go -h

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,92 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*.*.*"
+
+jobs:
+  build:
+    name: Build
+    # https://github.com/actions/virtual-environments/
+    runs-on: ubuntu-latest
+    steps:
+
+      - name: 🛎️ Checkout
+        uses: actions/checkout@v3
+
+      # https://github.com/marketplace/actions/setup-go-environment
+      - name: 🔧 Setup go
+        uses: actions/setup-go@v4
+        with:
+          go-version-file: 'go.mod'
+
+      - name: 🍳 Build
+        run: bash build.sh
+
+      # Test binary
+      - name: 🌡️ Test
+        run: chmod +x aegis-cli-linux-x86_64 && ./aegis-cli-linux-x86_64 -h
+
+      # Upload binaries
+      # https://github.com/marketplace/actions/upload-a-build-artifact
+      - name: 📤 Upload
+        uses: actions/upload-artifact@v3
+        with:
+          name: aegis-cli
+          path: aegis-cli*
+          retention-days: 1
+
+  test-linux:
+    name: Test Linux
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: 🛎️ Checkout
+        uses: actions/checkout@v3
+      # Download binaries
+      # https://github.com/marketplace/actions/download-a-build-artifact
+      - name: 📥 Download
+        uses: actions/download-artifact@v3
+        with:
+          name: aegis-cli
+      # Test binary
+      - name: 🌡️ Test
+        run: chmod +x aegis-cli-linux-x86_64 && ./aegis-cli-linux-x86_64 -h
+
+  test-macos:
+    name: Test macOS
+    needs: build
+    runs-on: macos-latest
+    steps:
+      - name: 🛎️ Checkout
+        uses: actions/checkout@v3
+      - name: 📥 Download
+        uses: actions/download-artifact@v3
+        with:
+          name: aegis-cli
+      # Test binary
+      - name: 🌡️ Test
+        run: chmod +x aegis-cli-macos-x86_64 && ./aegis-cli-macos-x86_64 -h
+
+  release:
+    name: Release
+    needs: [test-linux, test-macos]
+    runs-on: ubuntu-latest
+    steps:
+      - name: 🛎️ Checkout
+        uses: actions/checkout@v3
+      - name: 📥 Download
+        uses: actions/download-artifact@v3
+        with:
+          name: aegis-cli
+      # Release, upload files
+      # https://github.com/marketplace/actions/gh-release
+      - name: ✨ Release
+        uses: softprops/action-gh-release@v1
+        with:
+          files: |
+            aegis-cli-linux-x86_64
+            aegis-cli-linux-arm64
+            aegis-cli-macos-x86_64
+            aegis-cli-macos-arm64

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,8 @@
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
 
+aegis-cli-*
+
 # Dependency directories (remove the comment below to include it)
 # vendor/
 

--- a/README.md
+++ b/README.md
@@ -3,21 +3,80 @@ Command-line interface to generate 2FA from Aegis' json file
 
 # How to use
 
-1. Install the binary on your system
+## 1. Install
 
+<details>
+<summary><b>Linux</b></summary>
+
+Download:
+* [x86_64](https://github.com/navilg/aegis-cli/releases/latest/download/aegis-cli-linux-x86_64) Intel or AMD 64-Bit CPU
+  ```shell
+  curl -L "https://github.com/navilg/aegis-cli/releases/latest/download/aegis-cli-linux-x86_64" \
+       -o "aegis-cli" && \
+  chmod +x "aegis-cli"
+  ```
+* [arm64](https://github.com/navilg/aegis-cli/releases/latest/download/aegis-cli-linux-arm64) Arm-based 64-Bit CPU (i.e. in Raspberry Pi)
+  ```shell
+  curl -L "https://github.com/navilg/aegis-cli/releases/latest/download/aegis-cli-linux-arm64" \
+       -o "aegis-cli" && \
+  chmod +x "aegis-cli"
+  ```
+
+> To determine your OS version, run `getconf LONG_BIT` or `uname -m` at the command line.
+
+Move:
+```shell
+sudo mv aegis-cli /usr/bin/aegis-cli
 ```
-VERSION=latest # For specific version, VERSION=0.2.0
-curl -LO https://github.com/navilg/aegis-cli/raw/main/assets/bin/aegis-cli-linux-${VERSION}
-chmod +x aegis-cli-linux-${VERSION}
-sudo mv aegis-cli-linux-${VERSION} /usr/bin/aegis-cli
+
+</details>
+
+<details>
+<summary><b>macOS</b></summary>
+
+Download:
+* [x86_64](https://github.com/navilg/aegis-cli/releases/latest/download/aegis-cli-macos-x86_64) Intel 64-bit
+  ```shell
+  curl -L "https://github.com/navilg/aegis-cli/releases/latest/download/aegis-cli-macos-x86_64" \
+       -o "aegis-cli" && \
+  chmod +x "aegis-cli"
+  ```
+* [arm64](https://github.com/navilg/aegis-cli/releases/latest/download/aegis-cli-macos-arm64) Apple silicon 64-bit
+  ```shell
+  curl -L "https://github.com/navilg/aegis-cli/releases/latest/download/aegis-cli-macos-arm64" \
+       -o "aegis-cli" && \
+  chmod +x "aegis-cli"
+  ```
+
+> To determine your OS version, run `uname -m` at the command line.
+
+Move:
+```shell
+mv aegis-cli ~/Applications/aegis-cli
 ```
 
-2. Export vault (encryoted) from your mobile app and put the vault file on your system under `$HOME/.config/aegis-cli` with filename `aegis.json`
+Tip:
 
+* Add `~/Applications/` to your `$PATH`
+    ```shell
+    echo 'export PATH="$HOME/Applications/:$PATH"' >> ~/.zshrc
+    ```
+* Or, add `~/Applications/aegis-cli` as alias for `aegis-cli`
+    ```shell
+    echo 'alias aegis-cli="$HOME/Applications/aegis-cli"' >> ~/.zshrc
+    ```
 
-3. Execute aegis cli
+</details>
 
-```
+## 2. Export
+
+Export vault (encrypted) from your mobile app and put the vault file on your system under `$HOME/.config/aegis-cli` with filename `aegis.json`.
+
+## 3. Execute
+
+Execute aegis cli:
+
+```shell
 aegis-cli
 ```
 
@@ -43,7 +102,7 @@ Vault is encrypted using 256-bit master key. This master key is encrypted with c
 
 Vault format:
 
-```
+```json
 {
     "version": 1,
     "header": {},
@@ -55,7 +114,7 @@ db contains vault content. If its encrypted, Its value is base64 encoded (with p
 
 Header contains `slots` and `params`. 
 
-```
+```json
 {
     "slots": [],
     "params": {

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+go version || exit 9
+
+# Linux
+echo "Linux"                                                       && \
+GOOS=linux GOARCH=amd64 go build -o aegis-cli-linux-x86_64 main.go && \
+GOOS=linux GOARCH=arm64 go build -o aegis-cli-linux-arm64  main.go && \
+
+# macOS
+echo "macOS"                                                        && \
+GOOS=darwin GOARCH=amd64 go build -o aegis-cli-macos-x86_64 main.go && \
+GOOS=darwin GOARCH=arm64 go build -o aegis-cli-macos-arm64  main.go && \
+
+echo "✅ DONE"


### PR DESCRIPTION
Hi,

I created some GitHub Actions to test and compile the Go program. A Linux or Mac user can then download the compiled and ready to use version from the release (and not the repo).

You must adjust the [Workflow permissions](https://github.com/navilg/aegis-cli/settings/actions) and allow read and write:

![image](https://user-images.githubusercontent.com/176242/227923013-444bf56c-5ec5-4c0a-998d-219edac22a8d.png)

Then you can create a release with the tag format `v*.*.*`.

GitHub Action will compile and upload the compiled binaries to the release.

Example: https://github.com/Cyclenerd/aegis-cli/releases

The README.md is optimized for copy and paste.

Note: I'm tested your CLI program with macOS Ventura (13.2.1) and M1 CPU.

Best regards
Nils